### PR TITLE
set timeout for opensearch

### DIFF
--- a/.github/workflows/cypress-workflow-bundle-snapshot-based.yml
+++ b/.github/workflows/cypress-workflow-bundle-snapshot-based.yml
@@ -28,7 +28,7 @@ jobs:
           tar -xzf opensearch-1.0.1-linux-x64.tar.gz
           cd opensearch-1.0.1/
           ./opensearch-tar-install.sh &
-          timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' -u admin:admin -k localhost:9200)" != "200" ]]; do sleep 5; done'
+          timeout 900 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' -u admin:admin -k localhost:9200)" != "200" ]]; do sleep 5; done'
       - name: Get OpenSearch-Dashboards
         run: |
           wget https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.0.1/opensearch-dashboards-1.0.1-linux-x64.tar.gz

--- a/.github/workflows/cypress-workflow-bundle-snapshot-based.yml
+++ b/.github/workflows/cypress-workflow-bundle-snapshot-based.yml
@@ -28,7 +28,7 @@ jobs:
           tar -xzf opensearch-1.0.1-linux-x64.tar.gz
           cd opensearch-1.0.1/
           ./opensearch-tar-install.sh &
-          timeout 900 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' -u admin:admin -k localhost:9200)" != "200" ]]; do sleep 5; done'
+          timeout 900 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' -u admin:admin -k https://localhost:9200)" != "200" ]]; do sleep 5; done'
       - name: Get OpenSearch-Dashboards
         run: |
           wget https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.0.1/opensearch-dashboards-1.0.1-linux-x64.tar.gz

--- a/.github/workflows/cypress-workflow-bundle-snapshot-based.yml
+++ b/.github/workflows/cypress-workflow-bundle-snapshot-based.yml
@@ -27,7 +27,8 @@ jobs:
           wget https://artifacts.opensearch.org/releases/bundle/opensearch/1.0.1/opensearch-1.0.1-linux-x64.tar.gz
           tar -xzf opensearch-1.0.1-linux-x64.tar.gz
           cd opensearch-1.0.1/
-          ./opensearch-tar-install.sh
+          ./opensearch-tar-install.sh &
+          timeout 30
       - name: Get OpenSearch-Dashboards
         run: |
           wget https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.0.1/opensearch-dashboards-1.0.1-linux-x64.tar.gz

--- a/.github/workflows/cypress-workflow-bundle-snapshot-based.yml
+++ b/.github/workflows/cypress-workflow-bundle-snapshot-based.yml
@@ -28,7 +28,7 @@ jobs:
           tar -xzf opensearch-1.0.1-linux-x64.tar.gz
           cd opensearch-1.0.1/
           ./opensearch-tar-install.sh &
-          timeout 30
+          timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' -u admin:admin -k localhost:9200)" != "200" ]]; do sleep 5; done'
       - name: Get OpenSearch-Dashboards
         run: |
           wget https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/1.0.1/opensearch-dashboards-1.0.1-linux-x64.tar.gz


### PR DESCRIPTION
The workflow for bundled osd has been failing. It turns out to be the health check which shall be against https instead of http. See the following Github Action results.